### PR TITLE
review suggestions

### DIFF
--- a/client/container_create.go
+++ b/client/container_create.go
@@ -32,6 +32,10 @@ func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config
 	if err := cli.NewVersionError("1.44", "specify health-check start interval"); config != nil && config.Healthcheck != nil && config.Healthcheck.StartInterval != 0 && err != nil {
 		return response, err
 	}
+	if err := cli.NewVersionError("1.44", "specify mac-address per network"); config != nil && config.MacAddress != "" && err != nil {
+		return response, err
+	}
+	// TODO{thaJeztah): should we convert --mac-address to NetworkingConfig[<container network "mode">].MacAddress on API < 1.44 ??
 
 	if hostConfig != nil {
 		if versions.LessThan(cli.ClientVersion(), "1.25") {

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -27,8 +27,14 @@ func (daemon *Daemon) ContainerInspect(ctx context.Context, name string, size bo
 		return daemon.containerInspectPre120(ctx, name)
 	case versions.Equal(version, "1.20"):
 		return daemon.containerInspect120(name)
+	case versions.LessThan(version, "1.44"):
+		return daemon.ContainerInspectCurrent(ctx, name, size)
 	}
-	return daemon.ContainerInspectCurrent(ctx, name, size)
+	// We unconditionally set the top-level MacAddress field, but it
+	// is deprecated on API >= 1.44, so reset the field.
+	ctr, err := daemon.ContainerInspectCurrent(ctx, name, size)
+	ctr.Config.MacAddress = "" //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
+	return ctr, err
 }
 
 // ContainerInspectCurrent returns low-level information about a
@@ -116,7 +122,7 @@ func (daemon *Daemon) containerInspect120(name string) (*v1p20.ContainerJSON, er
 		Mounts:            ctr.GetMountPoints(),
 		Config: &v1p20.ContainerConfig{
 			Config:          ctr.Config,
-			MacAddress:      ctr.Config.MacAddress, //nolint:staticcheck
+			MacAddress:      ctr.Config.MacAddress, //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
 			NetworkDisabled: ctr.Config.NetworkDisabled,
 			ExposedPorts:    ctr.Config.ExposedPorts,
 			VolumeDriver:    ctr.HostConfig.VolumeDriver,
@@ -137,6 +143,18 @@ func (daemon *Daemon) getInspectData(daemonCfg *config.Config, container *contai
 
 	// We merge the Ulimits from hostConfig with daemon default
 	daemon.mergeUlimits(&hostConfig, daemonCfg)
+
+	// Migrate the container's default network's MacAddress to the top-level
+	// Config.MacAddress field for older API versions (< 1.44). We set it
+	// here unconditionally, but this field will be emptied on current
+	// API versions (>= 1.44).
+	if container.Config != nil && container.Config.MacAddress == "" { //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
+		if nwm := hostConfig.NetworkMode; nwm.IsDefault() || nwm.IsBridge() || nwm.IsUserDefined() {
+			if epConf, ok := container.NetworkSettings.Networks[nwm.NetworkName()]; ok {
+				container.Config.MacAddress = epConf.MacAddress //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
+			}
+		}
+	}
 
 	var containerHealth *types.Health
 	if container.State.Health != nil {

--- a/daemon/inspect_linux.go
+++ b/daemon/inspect_linux.go
@@ -47,7 +47,7 @@ func (daemon *Daemon) containerInspectPre120(ctx context.Context, name string) (
 		VolumesRW:         volumesRW,
 		Config: &v1p19.ContainerConfig{
 			Config:          ctr.Config,
-			MacAddress:      ctr.Config.MacAddress, //nolint:staticcheck
+			MacAddress:      ctr.Config.MacAddress, //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
 			NetworkDisabled: ctr.Config.NetworkDisabled,
 			ExposedPorts:    ctr.Config.ExposedPorts,
 			VolumeDriver:    ctr.HostConfig.VolumeDriver,


### PR DESCRIPTION
- related to https://github.com/docker/cli/pull/4419


-----

- make sure we don't reset the macAddress on older API versions
- on API >= 1.44 return a warning if the top-level macAddress was set
- on API < 1.44, restore the top-level macAddress from the default network (networkMode)
- add a client-error when trying to use the top-level macAddress on API >= 1.44
- added a TODO for migrating in the client (?)
- probably other changes may still be needed ':-)


