### PR TITLE
allow privileged and read-only rootfs on Windows host

### DIFF
--- a/daemon/internal/runconfig/hostconfig_windows.go
+++ b/daemon/internal/runconfig/hostconfig_windows.go
@@ -33,18 +33,16 @@ func validateResources(hc *container.HostConfig, _ *sysinfo.SysInfo) error {
 	return nil
 }
 
-// validatePrivileged performs platform specific validation of the Privileged setting
-func validatePrivileged(hc *container.HostConfig) error {
-	if hc.Privileged {
-		return validationError("invalid option: privileged mode is not supported for Windows containers")
-	}
+// validatePrivileged performs platform specific validation of the Privileged setting.
+// docker-next always runs Linux containers in VMs regardless of host OS,
+// so Windows container restrictions do not apply.
+func validatePrivileged(_ *container.HostConfig) error {
 	return nil
 }
 
-// validateReadonlyRootfs performs platform specific validation of the ReadonlyRootfs setting
-func validateReadonlyRootfs(hc *container.HostConfig) error {
-	if hc.ReadonlyRootfs {
-		return validationError("invalid option: read-only mode is not supported for Windows containers")
-	}
+// validateReadonlyRootfs performs platform specific validation of the ReadonlyRootfs setting.
+// docker-next always runs Linux containers in VMs regardless of host OS,
+// so Windows container restrictions do not apply.
+func validateReadonlyRootfs(_ *container.HostConfig) error {
 	return nil
 }


### PR DESCRIPTION
moby's runconfig validation rejects privileged mode and read-only root filesystem when the host OS is Windows, as these are not supported for native Windows containers. However, it's possible to run Linux containers in VMs regardless of host OS, so these restrictions don't apply always.

Make validatePrivileged and validateReadonlyRootfs no-ops on Windows, matching the Unix behavior.
