### PR TITLE
fix: replace exec.Command sysctl with unix.SysctlUint32 to eliminate fork

### DIFF
--- a/daemon/libnetwork/portallocator/dynamicportrange_darwin.go
+++ b/daemon/libnetwork/portallocator/dynamicportrange_darwin.go
@@ -3,9 +3,9 @@
 package portallocator
 
 import (
-	"bytes"
 	"fmt"
-	"os/exec"
+
+	"golang.org/x/sys/unix"
 )
 
 func getDynamicPortRange() (start, end int, _ error) {
@@ -13,17 +13,11 @@ func getDynamicPortRange() (start, end int, _ error) {
 		"net.inet.ip.portrange.hifirst": &start,
 		"net.inet.ip.portrange.hilast":  &end,
 	} {
-		var buf bytes.Buffer
-		cmd := exec.Command("/usr/sbin/sysctl", sysctl)
-		cmd.Stdout = &buf
-		if err := cmd.Run(); err != nil {
+		v, err := unix.SysctlUint32(sysctl)
+		if err != nil {
 			return 0, 0, fmt.Errorf("port allocator - sysctl %s failed: %v", sysctl, err)
 		}
-
-		n, err := fmt.Sscanf(buf.String(), sysctl+": %d\n", val)
-		if err != nil || n != 1 {
-			return 0, 0, fmt.Errorf("failed to parse the output of sysctl %s: %v", sysctl, err)
-		}
+		*val = int(v)
 	}
 
 	return start, end, nil


### PR DESCRIPTION
## Summary

On macOS, `getDynamicPortRange()` forks a subprocess via `exec.Command("/usr/sbin/sysctl", ...)`
to read port range values. This intermittently deadlocks on macOS arm64 CI, causing parallel
unit tests to timeout.

The fix replaces the fork+exec with `unix.SysctlUint32()`, which reads the kernel value
directly via the sysctl syscall — sidestepping fork, no child process, no atfork handlers.

- Replace `exec.Command("/usr/sbin/sysctl")` with `unix.SysctlUint32()` in `dynamicportrange_darwin.go`
- Eliminates the `fork()` call that can deadlock in Apple libc atfork handlers
- Linux and Windows are unaffected (Linux reads `/proc`, Windows uses hardcoded values)

## What Changed

`daemon/libnetwork/portallocator/dynamicportrange_darwin.go`: replaced the `exec.Command` +
stdout parsing with a direct `unix.SysctlUint32()` call for each sysctl key. Removed `bytes`
and `os/exec` imports, added `golang.org/x/sys/unix` (already a dependency).

## Extra context


**A hypothesis on the deadlock mechanism:** Go does not use `posix_spawn` — it calls `fork()` and `execve()` as
separate syscalls (`exec_libc2.go`). Between those two calls, in the child process, Apple's libc
runs atfork handlers (`libSystem_atfork_child`). These handlers can deadlock if another thread in
the parent held a libc lock (e.g., `os_alloc_once`, ObjC runtime class initialization) at the
moment of `fork()`. The parent then blocks forever in `wait4()`, waiting for a child that will
never exec.

Other possible issues pointing at the same problem:
- [golang/go#56784](https://github.com/golang/go/issues/56784) — filed by Russ Cox as a release-blocker
- [golang/go#61080](https://github.com/golang/go/issues/61080) — concurrent `forkExec` hangs on darwin
- [Apple Developer Forums](https://developer.apple.com/forums/thread/737464?answerId=764686022#764686022) — Apple DTS confirms fork+exec without `posix_spawn` is unsafe with Apple frameworks due to Mach/BSD disconnect

Go's runtime workarounds (calling `__fork` instead of libc `fork`) are timing-dependent and
can still fail under thread contention, especially with the race detector adding threads.

**CI analysis:** We analyzed 15 days of CI history on `docker/docker-next` (~236 macOS test job
executions). Found 1 confirmed gvisor timeout instance (~0.4% failure rate).
**Reproduction attempts:** We built a stress-test harness (50 iterations, `-race`, `GOMAXPROCS=32`)
and ran it on the same self-hosted macOS arm64 CI runner. It did not trigger the hang — the race
window is too narrow to reproduce reliably outside of specific CI load conditions. However,
replacing `exec.Command` with `/bin/sleep 60` reproduces the exact CI failure (same panic, same
goroutine stacks), confirming delays in `getDynamicPortRange()` cause the timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)